### PR TITLE
optional param compare added to set method.  If true, set will JSON c…

### DIFF
--- a/spec/store_spec.js
+++ b/spec/store_spec.js
@@ -188,6 +188,26 @@ describe('store', () => {
       expect(actual).toBe(expected);
     });
 
+    it('should not set value if it is unchanged and compare is true', () => {
+      let spyCb = jasmine.createSpy('watch callback');
+
+      store.set('food', {test: 'test'});
+      store.watch('food', spyCb)
+      store.set('food', {test: 'test'}, true);
+
+      expect(spyCb).not.toHaveBeenCalled();
+    });
+
+    it('should set value if it is changed and compare is true', () => {
+      let spyCb = jasmine.createSpy('watch callback');
+
+      store.set('food', {test: 'test1'});
+      store.watch('food', spyCb)
+      store.set('food', {test: 'test2'}, true);
+
+      expect(spyCb).toHaveBeenCalled();
+    });
+
     it('should get the desired value for a nested key', () => {
       store.set('user.id', 2);
 

--- a/spec/store_spec.js
+++ b/spec/store_spec.js
@@ -188,24 +188,37 @@ describe('store', () => {
       expect(actual).toBe(expected);
     });
 
-    it('should not set value if it is unchanged and compare is true', () => {
-      let spyCb = jasmine.createSpy('watch callback');
+    it('should not set value or trigger watch if value is same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
 
-      store.set('food', {test: 'test'});
-      store.watch('food', spyCb)
-      store.set('food', {test: 'test'}, true);
+      store.watch(['food'], () => ++count);
+      store.set('food', {test: 'original data'}, options);
+      store.set('food', {test: 'original data'}, options);
 
-      expect(spyCb).not.toHaveBeenCalled();
+      expect(count).toBe(1);
     });
 
-    it('should set value if it is changed and compare is true', () => {
-      let spyCb = jasmine.createSpy('watch callback');
+    it('should set value and trigger watch even if value is same as original, when options.compare is false', () => {
+      let count = 0;
+      let options = { compare: false }
 
-      store.set('food', {test: 'test1'});
-      store.watch('food', spyCb)
-      store.set('food', {test: 'test2'}, true);
+      store.watch(['food'], () => ++count);
+      store.set('food', {test: 'original data'}, options);
+      store.set('food', {test: 'original data'}, options);
 
-      expect(spyCb).toHaveBeenCalled();
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if value is changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', {test: 'original data'}, options);
+      store.set('food', {test: 'data has changed'}, options);
+
+      expect(count).toBe(2);
     });
 
     it('should get the desired value for a nested key', () => {

--- a/spec/store_spec.js
+++ b/spec/store_spec.js
@@ -188,13 +188,68 @@ describe('store', () => {
       expect(actual).toBe(expected);
     });
 
-    it('should not set value or trigger watch if value is same as original and options.compare is true', () => {
+    it('should not set value or trigger watch if object is same as original and options.compare is true', () => {
       let count = 0;
       let options = { compare: true }
 
       store.watch(['food'], () => ++count);
       store.set('food', {test: 'original data'}, options);
       store.set('food', {test: 'original data'}, options);
+
+      expect(count).toBe(1);
+    });
+
+    it('should not set value or trigger watch parent watcher if child values are the same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', {test: 'original data'}, options);
+      store.set('food.test', 'original data', options);
+
+      expect(count).toBe(1);
+    });
+
+    it('should not set value or trigger watch if string is same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', 'test', options);
+      store.set('food', 'test', options);
+
+      expect(count).toBe(1);
+    });
+
+    it('should not set value or trigger watch if boolean is same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', true, options);
+      store.set('food', true, options);
+
+      expect(count).toBe(1);
+    });
+
+    it('should not set value or trigger watch if number is same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', 123, options);
+      store.set('food', 123, options);
+
+      expect(count).toBe(1);
+    });
+
+    it('should not set value or trigger watch if array is same as original and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', [1, '2'], options);
+      store.set('food', [1, '2'], options);
 
       expect(count).toBe(1);
     });
@@ -210,13 +265,68 @@ describe('store', () => {
       expect(count).toBe(2);
     });
 
-    it('should set value and trigger watch if value is changed and options.compare is true', () => {
+    it('should set value and trigger watch for parent watcher if chlid values are changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', {test: 'original data'}, options);
+      store.set('food.test', 'newer data', options);
+
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if object is changed and options.compare is true', () => {
       let count = 0;
       let options = { compare: true }
 
       store.watch(['food'], () => ++count);
       store.set('food', {test: 'original data'}, options);
       store.set('food', {test: 'data has changed'}, options);
+
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if string is changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', 'test', options);
+      store.set('food', 'new test', options);
+
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if boolean is changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', true, options);
+      store.set('food', false, options);
+
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if number is changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', 123, options);
+      store.set('food', 1234, options);
+
+      expect(count).toBe(2);
+    });
+
+    it('should set value and trigger watch if array is changed and options.compare is true', () => {
+      let count = 0;
+      let options = { compare: true }
+
+      store.watch(['food'], () => ++count);
+      store.set('food', [1, 2], options);
+      store.set('food', [1, '2'], options);
 
       expect(count).toBe(2);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -143,9 +143,10 @@ function create(defaultState = {}) {
    *
    * @param {String} path
    * @param {mixed} value
+   * @param {Boolean} value
    * @return null
    */
-  function set(path, value) {
+  function set(path, value, compare) {
     let paths = _pathsArray(path);
 
     // Get all paths to notify for updates if given an object
@@ -155,6 +156,15 @@ function create(defaultState = {}) {
       // If previous value was also an object, we need to see which keys have
       // changed to notify watchers on those keys
       if (_isObject(existingValue)) {
+        
+        // If using compare = true.  JSON.strigify compare the two sets of data.
+        // If they are exactly the same, abort the update.
+        if (compare) {
+          if (JSON.stringify(value) === JSON.stringify(existingValue)) {
+            return;
+          }
+        }
+        
         let oldKeys = _deepKeys(existingValue, path);
         let removedKeys;
 

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ function create(defaultState = {}) {
    * @param {Boolean} value
    * @return null
    */
-  function set(path, value, compare) {
+  function set(path, value, options = {}) {
     let paths = _pathsArray(path);
 
     // Get all paths to notify for updates if given an object
@@ -157,9 +157,9 @@ function create(defaultState = {}) {
       // changed to notify watchers on those keys
       if (_isObject(existingValue)) {
         
-        // If using compare = true.  JSON.strigify compare the two sets of data.
+        // If using options.compare = true.  JSON.strigify compare the two sets of data.
         // If they are exactly the same, abort the update.
-        if (compare) {
+        if (options.compare) {
           if (JSON.stringify(value) === JSON.stringify(existingValue)) {
             return;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -148,22 +148,25 @@ function create(defaultState = {}) {
    */
   function set(path, value, options = {}) {
     let paths = _pathsArray(path);
+    let existingValue;
+
+    // If using options.compare = true.  JSON.strigify compare the two sets of data.
+    // If they are exactly the same, abort the update.
+    if (options.compare) {
+      existingValue = getSilent(path);
+
+      if (JSON.stringify(value) === JSON.stringify(existingValue)) {
+        return;
+      }
+    }
 
     // Get all paths to notify for updates if given an object
     if (_isObject(value) === true) {
-      let existingValue = getSilent(path);
+      existingValue = existingValue || getSilent(path);
 
       // If previous value was also an object, we need to see which keys have
       // changed to notify watchers on those keys
       if (_isObject(existingValue)) {
-        
-        // If using options.compare = true.  JSON.strigify compare the two sets of data.
-        // If they are exactly the same, abort the update.
-        if (options.compare) {
-          if (JSON.stringify(value) === JSON.stringify(existingValue)) {
-            return;
-          }
-        }
         
         let oldKeys = _deepKeys(existingValue, path);
         let removedKeys;


### PR DESCRIPTION
compare the existing value and the new value, if they are the same, set will abort.

This is intended to prevent calls to watchers when the data did not change.

FYI:  I did cost testing and JSON.stringify(a) === JSON.stringify(b)
with very large / complex objects were costing ~ 1 ms.

jsfiddle https://jsfiddle.net/dpcassil/1dpqt7bo/2/
hope that works without a log in.  its much slower in js fiddle but that will give you an idea.  that is a lot of data.